### PR TITLE
Improve RSS feed metadata and styling

### DIFF
--- a/src/org_blog/pages/rss.clj
+++ b/src/org_blog/pages/rss.clj
@@ -2,15 +2,48 @@
   (:require
    [clojure.data.xml :as xml]
    [clojure.java.io :as io]
+   [clojure.string :as str]
    [org-blog.common.files :refer [posts-org-dir spit-with-path]]
+   [org-blog.common.org :refer [extract-org-metadata]]
    [org-blog.posts :as posts]
    [potpuri.core :as pot]
    [clojure.pprint :refer [pprint]]))
 
-(defn create-rss-item [post-name]
-  (xml/element :item {}
-               (xml/element :title {} post-name)
-               (xml/element :link {} (str "http://jgood.online/posts/" post-name)))) ;; TODO
+(import '[java.time LocalDate ZoneId ZonedDateTime]
+        '[java.time.format DateTimeFormatter]
+        '[java.util Locale])
+
+(def rfc822-formatter
+  (DateTimeFormatter/ofPattern "EEE, dd MMM yyyy HH:mm:ss Z" Locale/US))
+
+(def base-url "http://jgood.online")
+
+(defn format-pub-date [date-str]
+  (let [ld   (LocalDate/parse date-str)
+        zdt  (.atStartOfDay ld (ZoneId/of "UTC"))]
+    (.format rfc822-formatter zdt)))
+
+(defn extract-date-from-name [post-name]
+  (second (re-find #"\d{4}-\d{2}-\d{2}" post-name)))
+
+(defn create-rss-item [org-file]
+  (let [post-name  (posts/get-org-file-name org-file)
+        org-content (slurp org-file)
+        metadata   (extract-org-metadata org-content)
+        title      (or (:title metadata) post-name)
+        description (:description metadata)
+        link       (str base-url "/posts/" post-name)
+        pub-date   (when-let [d (or (:date metadata)
+                                    (extract-date-from-name post-name))]
+                     (format-pub-date d))]
+    (xml/element :item {}
+                 (xml/element :title {} title)
+                 (xml/element :link {} link)
+                 (when description
+                   (xml/element :description {} description))
+                 (when pub-date
+                   (xml/element :pubDate {} pub-date))
+                 (xml/element :guid {} link))))
 
 (defn create-rss-feed [items]
   (xml/element :rss {:version "2.0"}
@@ -20,11 +53,7 @@
                             (xml/element :description {} "Still trying to figure out what to write about")
                             items)))
 
-;; TODO Add more metadata
-;; <description> or <content>: A summary or the full content of the post.
-;; <pubDate>: The publication date of the post.
-;; <guid>: A globally unique identifier for the post.
-;; TODO XSLT (Extensible Stylesheet Language Transformations)
+;; Generate RSS feed for all posts with description, pubDate, guid, and XSLT styling
 (defn gen []
   (println "Generating RSS feed")
   (let [items (->> posts-org-dir
@@ -32,10 +61,12 @@
                    file-seq
                    (filter #(re-matches #".*\.org" (.getName %)))
                    (sort)
-                   (map #(str (.getCanonicalPath %)))
-                   (map (fn [org-file]
-                          (let [post-name (posts/get-org-file-name org-file)]
-                            (create-rss-item post-name)))))
-        rss-feed (create-rss-feed items)]
-    (with-open [out-file (java.io.FileWriter. "./static/rss.xml")]
-      (xml/emit rss-feed out-file))))
+                   (map #(.getCanonicalPath %))
+                   (map create-rss-item))
+        rss-feed (create-rss-feed items)
+        xml-str  (xml/indent-str rss-feed)
+        xml-str  (str/replace-first xml-str
+                                    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                                    (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                                         "<?xml-stylesheet type=\"text/xsl\" href=\"/rss.xsl\"?>"))]
+    (spit-with-path "./static/rss.xml" xml-str)))

--- a/static/rss.xml
+++ b/static/rss.xml
@@ -1,1 +1,29 @@
-<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><channel><title>Justin Good's Blog</title><link>http://jgood.online</link><description>Still trying to figure out what to write about</description><item><title>2023-04-22-kitchen-sink</title><link>http://jgood.online/posts/2023-04-22-kitchen-sink</link></item><item><title>2023-05-20-org-blog</title><link>http://jgood.online/posts/2023-05-20-org-blog</link></item><item><title>2023-11-12-htmx-search</title><link>http://jgood.online/posts/2023-11-12-htmx-search</link></item></channel></rss>
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="/rss.xsl"?><rss version="2.0">
+  <channel>
+    <title>Justin Good's Blog</title>
+    <link>http://jgood.online</link>
+    <description>Still trying to figure out what to write about</description>
+    <item>
+      <title>Hello World!</title>
+      <link>http://jgood.online/posts/2023-04-22-kitchen-sink</link>
+      <description>A kitchen sink of org mode elements to test rendering to html</description>
+      <pubDate>Sat, 22 Apr 2023 00:00:00 +0000</pubDate>
+      <guid>http://jgood.online/posts/2023-04-22-kitchen-sink</guid>
+    </item>
+    <item>
+      <title>Building a Custom Static Site Generator</title>
+      <link>http://jgood.online/posts/2023-05-20-org-blog</link>
+      <description>Because the world needs another static site generator and I want to write in org mode</description>
+      <pubDate>Sat, 20 May 2023 00:00:00 +0000</pubDate>
+      <guid>http://jgood.online/posts/2023-05-20-org-blog</guid>
+    </item>
+    <item>
+      <title>Typeahead Search with HTMX</title>
+      <link>http://jgood.online/posts/2023-11-12-htmx-search</link>
+      <description>Real example of a typeahead search implementation that includes filter options and URL state sync</description>
+      <pubDate>Sun, 12 Nov 2023 00:00:00 +0000</pubDate>
+      <guid>http://jgood.online/posts/2023-11-12-htmx-search</guid>
+    </item>
+  </channel>
+</rss>

--- a/static/rss.xsl
+++ b/static/rss.xsl
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="html" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <head>
+        <title>Justin Good's Blog RSS Feed</title>
+      </head>
+      <body>
+        <h1>Justin Good's Blog RSS Feed</h1>
+        <ul>
+          <xsl:for-each select="rss/channel/item">
+            <li>
+              <a href="{link}"><xsl:value-of select="title"/></a>
+              <p><xsl:value-of select="description"/></p>
+              <small><xsl:value-of select="pubDate"/></small>
+            </li>
+          </xsl:for-each>
+        </ul>
+      </body>
+    </html>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
## Summary
- enrich RSS feed items with descriptions, pubDates and GUIDs
- format publication dates in RFC‑822 format
- include stylesheet reference and provide RSS XSL file
- regenerate `static/rss.xml`

## Testing
- `clojure -e "(require 'org-blog.core)(org-blog.core/regenerate-site)"` *(fails: Cannot invoke "String.length()" because "s" is null)*

------
https://chatgpt.com/codex/tasks/task_e_6849edfab74883278d98b020b2033835